### PR TITLE
Fix kustomization warning

### DIFF
--- a/k8s/zero/deployment/kustomization.yaml
+++ b/k8s/zero/deployment/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
   - base.yaml
-patchesStrategicMerge:
-  - env.yaml
-  - image.yaml
-  - ports.yaml
-  - resources.yaml
-  - no-root.yaml
-  - readonly-root-fs.yaml
-  - volumes.yaml
+patches:
+  - path: env.yaml
+  - path: image.yaml
+  - path: ports.yaml
+  - path: resources.yaml
+  - path: no-root.yaml
+  - path: readonly-root-fs.yaml
+  - path: volumes.yaml

--- a/k8s/zero/kustomization.yaml
+++ b/k8s/zero/kustomization.yaml
@@ -1,6 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: pomerium-zero
-commonLabels:
-  app.kubernetes.io/name: pomerium-zero
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: pomerium-zero
 resources:
   - namespace.yaml
   - ./rbac


### PR DESCRIPTION
## Summary

There were old kustomization logic used, such as commonLabels and different patch handling.

## Related issues

N/A

## User Explanation

`kustomization build` will not show any warning, and the result should be exactly the same as before.

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review